### PR TITLE
feat: Phase 1 - Claude Integration

### DIFF
--- a/src/vs/workbench/contrib/claude/browser/claude.contribution.ts
+++ b/src/vs/workbench/contrib/claude/browser/claude.contribution.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
+import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
+import { registerSingleton, InstantiationType } from '../../../../platform/instantiation/common/extensions.js';
+import { ILanguageModelStatsService } from '../../chat/common/languageModelStats.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { IClaudeApiClient, ClaudeApiClient } from '../common/claudeApiClient.js';
+import { IClaudeConfigurationService, ClaudeConfigurationService } from './claudeConfigurationService.js';
+import { ClaudeLanguageModelProvider } from '../common/claudeLanguageModelProvider.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { ILanguageModelsService } from '../../chat/common/languageModels.js';
+import './claudeCommands.js';
+
+class ClaudeWorkbenchContribution extends Disposable implements IWorkbenchContribution {
+
+	private claudeProvider: ClaudeLanguageModelProvider | undefined;
+
+	constructor(
+		@IClaudeApiClient private readonly claudeApiClient: IClaudeApiClient,
+		@IClaudeConfigurationService private readonly claudeConfigurationService: IClaudeConfigurationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILogService private readonly logService: ILogService,
+		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService
+	) {
+		super();
+
+		this._initialize();
+	}
+
+	private async _initialize(): Promise<void> {
+		// Initialize Claude API client with current configuration
+		this._updateClaudeConfiguration();
+
+		// Listen for configuration changes
+		this._register(this.claudeConfigurationService.onDidChangeConfiguration(() => {
+			this._updateClaudeConfiguration();
+		}));
+
+		// Register Claude language model provider
+		this._registerClaudeProvider();
+
+		this.logService.info('Claude integration initialized');
+	}
+
+	private _updateClaudeConfiguration(): void {
+		const config = this.claudeConfigurationService.getConfiguration();
+		this.claudeApiClient.configure(config);
+	}
+
+	private _registerClaudeProvider(): void {
+		if (this.claudeProvider) {
+			this.claudeProvider.dispose();
+		}
+
+		this.claudeProvider = new ClaudeLanguageModelProvider(
+			this.claudeApiClient,
+			this.configurationService,
+			this.logService
+		);
+
+		// Register with the language models service
+		this._register(this.languageModelsService.registerLanguageModelProvider('claude', this.claudeProvider));
+
+		this.logService.info('Claude language model provider registered');
+	}
+}
+
+// Register services
+registerSingleton(IClaudeApiClient, ClaudeApiClient, InstantiationType.Delayed);
+registerSingleton(IClaudeConfigurationService, ClaudeConfigurationService, InstantiationType.Delayed);
+
+// Register configuration schema
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	id: 'claude',
+	title: 'Claude AI Assistant',
+	type: 'object',
+	properties: {
+		'claude.apiKey': {
+			type: 'string',
+			description: 'API key for Claude AI service. Can also be set via CLAUDE_API_KEY environment variable.',
+			scope: 'application'
+		},
+		'claude.baseUrl': {
+			type: 'string',
+			default: 'https://api.anthropic.com',
+			description: 'Base URL for Claude API service',
+			scope: 'application'
+		},
+		'claude.model': {
+			type: 'string',
+			default: 'claude-3-5-sonnet-20241022',
+			enum: [
+				'claude-3-5-sonnet-20241022',
+				'claude-3-5-haiku-20241022',
+				'claude-3-opus-20240229'
+			],
+			enumDescriptions: [
+				'Claude 3.5 Sonnet - Most capable model',
+				'Claude 3.5 Haiku - Fastest model',
+				'Claude 3 Opus - Most powerful model'
+			],
+			description: 'Default Claude model to use',
+			scope: 'application'
+		},
+		'claude.maxTokens': {
+			type: 'number',
+			default: 4096,
+			minimum: 1,
+			maximum: 8192,
+			description: 'Maximum number of tokens to generate in responses',
+			scope: 'application'
+		},
+		'claude.temperature': {
+			type: 'number',
+			default: 0.7,
+			minimum: 0,
+			maximum: 1,
+			description: 'Controls randomness in responses (0 = more focused, 1 = more creative)',
+			scope: 'application'
+		}
+	}
+});
+
+// Register workbench contribution
+const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
+workbenchRegistry.registerWorkbenchContribution(ClaudeWorkbenchContribution, LifecyclePhase.Ready);

--- a/src/vs/workbench/contrib/claude/browser/claudeCommands.ts
+++ b/src/vs/workbench/contrib/claude/browser/claudeCommands.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IClaudeConfigurationService } from './claudeConfigurationService.js';
+import { IClaudeApiClient } from '../common/claudeApiClient.js';
+import { Categories } from '../../../common/actions.js';
+
+class ConfigureClaudeApiKeyAction extends Action2 {
+	static readonly ID = 'claude.configureApiKey';
+	static readonly LABEL = localize('claude.configureApiKey', 'Configure Claude API Key');
+
+	constructor() {
+		super({
+			id: ConfigureClaudeApiKeyAction.ID,
+			title: ConfigureClaudeApiKeyAction.LABEL,
+			category: Categories.Help,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+		const claudeConfigService = accessor.get(IClaudeConfigurationService);
+
+		const currentConfig = claudeConfigService.getConfiguration();
+
+		const apiKey = await quickInputService.input({
+			title: localize('claude.enterApiKey', 'Enter Claude API Key'),
+			prompt: localize('claude.apiKeyPrompt', 'Enter your Claude API key from console.anthropic.com'),
+			value: currentConfig.apiKey ? '••••••••••••••••' : '',
+			password: true,
+			validateInput: (value) => {
+				if (!value || value === '••••••••••••••••') {
+					return localize('claude.apiKeyRequired', 'API key is required');
+				}
+				if (!value.startsWith('sk-ant-')) {
+					return localize('claude.invalidApiKey', 'Invalid API key format. Claude API keys start with "sk-ant-"');
+				}
+				return undefined;
+			}
+		});
+
+		if (apiKey && apiKey !== '••••••••••••••••') {
+			try {
+				await claudeConfigService.updateConfiguration({ apiKey });
+				notificationService.info(localize('claude.apiKeyConfigured', 'Claude API key configured successfully'));
+			} catch (error) {
+				notificationService.error(localize('claude.configurationError', 'Failed to configure Claude API key: {0}', String(error)));
+			}
+		}
+	}
+}
+
+class TestClaudeConnectionAction extends Action2 {
+	static readonly ID = 'claude.testConnection';
+	static readonly LABEL = localize('claude.testConnection', 'Test Claude Connection');
+
+	constructor() {
+		super({
+			id: TestClaudeConnectionAction.ID,
+			title: TestClaudeConnectionAction.LABEL,
+			category: Categories.Help,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const notificationService = accessor.get(INotificationService);
+		const claudeApiClient = accessor.get(IClaudeApiClient);
+
+		if (!claudeApiClient.isConfigured()) {
+			notificationService.warn(localize('claude.notConfigured', 'Claude is not configured. Please set your API key first.'));
+			return;
+		}
+
+		try {
+			const notification = notificationService.notify({
+				severity: 'info',
+				message: localize('claude.testingConnection', 'Testing Claude connection...'),
+				progress: {
+					infinite: true
+				}
+			});
+
+			const isConnected = await claudeApiClient.testConnection();
+			notification.close();
+
+			if (isConnected) {
+				notificationService.info(localize('claude.connectionSuccess', 'Claude connection test successful!'));
+			} else {
+				notificationService.error(localize('claude.connectionFailed', 'Claude connection test failed. Please check your API key and internet connection.'));
+			}
+		} catch (error) {
+			notificationService.error(localize('claude.connectionError', 'Error testing Claude connection: {0}', String(error)));
+		}
+	}
+}
+
+registerAction2(ConfigureClaudeApiKeyAction);
+registerAction2(TestClaudeConnectionAction);

--- a/src/vs/workbench/contrib/claude/browser/claudeConfigurationService.ts
+++ b/src/vs/workbench/contrib/claude/browser/claudeConfigurationService.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IClaudeConfiguration } from '../common/claudeTypes.js';
+
+export const IClaudeConfigurationService = createDecorator<IClaudeConfigurationService>('claudeConfigurationService');
+
+export interface IClaudeConfigurationService {
+	readonly _serviceBrand: undefined;
+
+	readonly onDidChangeConfiguration: Event<IClaudeConfiguration>;
+
+	getConfiguration(): IClaudeConfiguration;
+	updateConfiguration(config: Partial<IClaudeConfiguration>): Promise<void>;
+	isConfigured(): boolean;
+}
+
+export class ClaudeConfigurationService extends Disposable implements IClaudeConfigurationService {
+	readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeConfiguration = this._register(new Emitter<IClaudeConfiguration>());
+	readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
+
+	private static readonly STORAGE_KEY = 'claude.configuration';
+	private static readonly CONFIG_SECTION = 'claude';
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService private readonly storageService: IStorageService
+	) {
+		super();
+
+		// Listen for configuration changes
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ClaudeConfigurationService.CONFIG_SECTION)) {
+				this._onDidChangeConfiguration.fire(this.getConfiguration());
+			}
+		}));
+	}
+
+	getConfiguration(): IClaudeConfiguration {
+		// Priority: 1. Settings, 2. Storage, 3. Environment variables, 4. Defaults
+		const settings = this.configurationService.getValue<Partial<IClaudeConfiguration>>(ClaudeConfigurationService.CONFIG_SECTION) || {};
+		const stored = this._getStoredConfiguration();
+
+		return {
+			apiKey: settings.apiKey || stored.apiKey || process.env.CLAUDE_API_KEY || '',
+			baseUrl: settings.baseUrl || stored.baseUrl || 'https://api.anthropic.com',
+			model: settings.model || stored.model || 'claude-3-5-sonnet-20241022',
+			maxTokens: settings.maxTokens || stored.maxTokens || 4096,
+			temperature: settings.temperature ?? stored.temperature ?? 0.7
+		};
+	}
+
+	async updateConfiguration(config: Partial<IClaudeConfiguration>): Promise<void> {
+		const current = this._getStoredConfiguration();
+		const updated = { ...current, ...config };
+
+		this.storageService.store(
+			ClaudeConfigurationService.STORAGE_KEY,
+			JSON.stringify(updated),
+			StorageScope.PROFILE,
+			StorageTarget.USER
+		);
+
+		this._onDidChangeConfiguration.fire(this.getConfiguration());
+	}
+
+	isConfigured(): boolean {
+		const config = this.getConfiguration();
+		return !!config.apiKey;
+	}
+
+	private _getStoredConfiguration(): Partial<IClaudeConfiguration> {
+		try {
+			const stored = this.storageService.get(ClaudeConfigurationService.STORAGE_KEY, StorageScope.PROFILE);
+			return stored ? JSON.parse(stored) : {};
+		} catch {
+			return {};
+		}
+	}
+}

--- a/src/vs/workbench/contrib/claude/common/claudeApiClient.ts
+++ b/src/vs/workbench/contrib/claude/common/claudeApiClient.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Event } from '../../../../base/common/event.js';
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IClaudeConfiguration, IClaudeMessage, IClaudeResponse, IClaudeStreamResponse, ClaudeModelId } from './claudeTypes.js';
+
+export const IClaudeApiClient = createDecorator<IClaudeApiClient>('claudeApiClient');
+
+export interface IClaudeApiClient {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Event fired when the API client configuration changes
+	 */
+	readonly onDidChangeConfiguration: Event<void>;
+
+	/**
+	 * Configure the API client with API key and other settings
+	 */
+	configure(config: IClaudeConfiguration): void;
+
+	/**
+	 * Check if the API client is properly configured
+	 */
+	isConfigured(): boolean;
+
+	/**
+	 * Send a message to Claude and get a streaming response
+	 */
+	sendMessage(
+		messages: IClaudeMessage[],
+		model: ClaudeModelId,
+		options?: {
+			maxTokens?: number;
+			temperature?: number;
+			tools?: any[];
+			toolChoice?: any;
+		},
+		onProgress?: (chunk: IClaudeStreamResponse) => void,
+		token?: CancellationToken
+	): Promise<IClaudeResponse>;
+
+	/**
+	 * Count tokens in a message (estimation)
+	 */
+	estimateTokens(text: string): number;
+
+	/**
+	 * Test the API connection
+	 */
+	testConnection(token?: CancellationToken): Promise<boolean>;
+}
+
+export class ClaudeApiClient implements IClaudeApiClient {
+	readonly _serviceBrand: undefined;
+
+	private _configuration: IClaudeConfiguration | undefined;
+	private readonly _onDidChangeConfiguration = new Event<void>();
+	readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
+
+	constructor() {
+	}
+
+	configure(config: IClaudeConfiguration): void {
+		this._configuration = { ...config };
+		this._onDidChangeConfiguration.fire();
+	}
+
+	isConfigured(): boolean {
+		return !!this._configuration?.apiKey;
+	}
+
+	async sendMessage(
+		messages: IClaudeMessage[],
+		model: ClaudeModelId,
+		options: {
+			maxTokens?: number;
+			temperature?: number;
+			tools?: any[];
+			toolChoice?: any;
+		} = {},
+		onProgress?: (chunk: IClaudeStreamResponse) => void,
+		token?: CancellationToken
+	): Promise<IClaudeResponse> {
+		if (!this._configuration) {
+			throw new Error('Claude API client is not configured');
+		}
+
+		const requestBody = {
+			model,
+			max_tokens: options.maxTokens || this._configuration.maxTokens || 4096,
+			temperature: options.temperature ?? this._configuration.temperature ?? 0.7,
+			messages: messages.filter(m => m.role !== 'system'),
+			system: messages.find(m => m.role === 'system')?.content,
+			stream: !!onProgress,
+			...(options.tools && { tools: options.tools }),
+			...(options.toolChoice && { tool_choice: options.toolChoice })
+		};
+
+		const baseUrl = this._configuration.baseUrl || 'https://api.anthropic.com';
+		const url = `${baseUrl}/v1/messages`;
+
+		const headers = {
+			'Content-Type': 'application/json',
+			'x-api-key': this._configuration.apiKey,
+			'anthropic-version': '2023-06-01'
+		};
+
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				headers,
+				body: JSON.stringify(requestBody),
+				signal: token?.onCancellationRequested ? AbortSignal.timeout(30000) : undefined
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				throw new Error(`Claude API error: ${response.status} ${response.statusText} - ${errorText}`);
+			}
+
+			if (onProgress) {
+				return this._handleStreamingResponse(response, onProgress, token);
+			} else {
+				return await response.json() as IClaudeResponse;
+			}
+		} catch (error) {
+			if (token?.isCancellationRequested) {
+				throw new Error('Request was cancelled');
+			}
+			throw error;
+		}
+	}
+
+	private async _handleStreamingResponse(
+		response: Response,
+		onProgress: (chunk: IClaudeStreamResponse) => void,
+		token?: CancellationToken
+	): Promise<IClaudeResponse> {
+		const reader = response.body?.getReader();
+		if (!reader) {
+			throw new Error('No response body');
+		}
+
+		const decoder = new TextDecoder();
+		let buffer = '';
+		let finalResponse: IClaudeResponse | undefined;
+
+		try {
+			while (true) {
+				if (token?.isCancellationRequested) {
+					throw new Error('Request was cancelled');
+				}
+
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split('\n');
+				buffer = lines.pop() || '';
+
+				for (const line of lines) {
+					if (line.startsWith('data: ')) {
+						const data = line.slice(6);
+						if (data === '[DONE]') continue;
+
+						try {
+							const chunk = JSON.parse(data) as IClaudeStreamResponse;
+							onProgress(chunk);
+
+							// Build final response from chunks
+							if (chunk.type === 'message_start' && chunk.message) {
+								finalResponse = chunk.message as IClaudeResponse;
+							} else if (chunk.type === 'content_block_delta' && chunk.delta && finalResponse) {
+								if (!finalResponse.content) {
+									finalResponse.content = [{ type: 'text', text: '' }];
+								}
+								if (finalResponse.content[0]) {
+									finalResponse.content[0].text += chunk.delta.text;
+								}
+							} else if (chunk.type === 'message_delta' && chunk.usage && finalResponse) {
+								finalResponse.usage = chunk.usage;
+							}
+						} catch (e) {
+							// Skip invalid JSON chunks
+						}
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+
+		if (!finalResponse) {
+			throw new Error('No valid response received from Claude API');
+		}
+
+		return finalResponse;
+	}
+
+	estimateTokens(text: string): number {
+		// Rough estimation: ~4 characters per token for English text
+		return Math.ceil(text.length / 4);
+	}
+
+	async testConnection(token?: CancellationToken): Promise<boolean> {
+		try {
+			const testMessage: IClaudeMessage = {
+				role: 'user',
+				content: 'Hello'
+			};
+
+			await this.sendMessage([testMessage], 'claude-3-5-haiku-20241022', { maxTokens: 10 }, undefined, token);
+			return true;
+		} catch (error) {
+			return false;
+		}
+	}
+}

--- a/src/vs/workbench/contrib/claude/common/claudeLanguageModelProvider.ts
+++ b/src/vs/workbench/contrib/claude/common/claudeLanguageModelProvider.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IProgress } from '../../../../platform/progress/common/progress.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import {
+	ILanguageModelChatProvider,
+	ILanguageModelChatMetadata,
+	ILanguageModelChatResponse,
+	ChatMessageRole,
+	IChatMessage,
+	IChatResponseStream,
+	ILanguageModelChatSelector
+} from './languageModels.js';
+import { IClaudeApiClient } from './claudeApiClient.js';
+import { CLAUDE_MODELS, ClaudeModelId, IClaudeMessage } from './claudeTypes.js';
+
+export class ClaudeLanguageModelProvider extends Disposable implements ILanguageModelChatProvider {
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange = this._onDidChange.event;
+
+	constructor(
+		private readonly claudeApiClient: IClaudeApiClient,
+		private readonly configurationService: IConfigurationService,
+		private readonly logService: ILogService
+	) {
+		super();
+
+		// Listen for Claude configuration changes
+		this._register(claudeApiClient.onDidChangeConfiguration(() => {
+			this._onDidChange.fire();
+		}));
+
+		// Listen for configuration changes
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('claude')) {
+				this._onDidChange.fire();
+			}
+		}));
+	}
+
+	async prepareLanguageModelChat(options: { silent: boolean }, token: CancellationToken): Promise<ILanguageModelChatMetadataAndIdentifier[]> {
+		if (!this.claudeApiClient.isConfigured()) {
+			if (!options.silent) {
+				this.logService.warn('Claude API client is not configured');
+			}
+			return [];
+		}
+
+		// Test connection if not silent
+		if (!options.silent) {
+			try {
+				const isConnected = await this.claudeApiClient.testConnection(token);
+				if (!isConnected) {
+					this.logService.error('Failed to connect to Claude API');
+					return [];
+				}
+			} catch (error) {
+				this.logService.error('Error testing Claude API connection:', error);
+				return [];
+			}
+		}
+
+		// Return available Claude models
+		return Object.entries(CLAUDE_MODELS).map(([id, modelInfo]) => ({
+			identifier: `claude-${id}`,
+			metadata: {
+				extension: { value: 'internal.claude' } as any, // ExtensionIdentifier for internal Claude provider
+				id: id as ClaudeModelId,
+				name: modelInfo.name,
+				family: modelInfo.family,
+				vendor: 'claude',
+				description: `${modelInfo.name} - Advanced AI assistant by Anthropic`,
+				version: id.split('-').pop() || '1.0',
+				maxInputTokens: modelInfo.maxInputTokens,
+				maxOutputTokens: modelInfo.maxOutputTokens,
+				isDefault: id === 'claude-3-5-sonnet-20241022',
+				isUserSelectable: true,
+				modelPickerCategory: { label: 'Claude', order: 1 }
+			}
+		}));
+	}
+
+	async sendChatRequest(
+		modelId: string,
+		messages: IChatMessage[],
+		from: ExtensionIdentifier,
+		options: { [name: string]: any },
+		token: CancellationToken
+	): Promise<ILanguageModelChatResponse> {
+		this.logService.info(`Claude chat request for model ${modelId}`);
+
+		try {
+			// Extract actual Claude model ID from the identifier
+			const actualModelId = modelId.replace('claude-', '') as ClaudeModelId;
+
+			// Convert VS Code messages to Claude format
+			const claudeMessages = this._convertMessagesToClaude(messages);
+
+			// Extract tools if provided
+			const tools = options.tools?.map((tool: any) => ({
+				name: tool.name,
+				description: tool.description,
+				input_schema: tool.inputSchema || {}
+			}));
+
+			let responseText = '';
+
+			const claudeResponse = await this.claudeApiClient.sendMessage(
+				claudeMessages,
+				actualModelId,
+				{
+					maxTokens: options.maxTokens || 4096,
+					temperature: options.temperature || 0.7,
+					tools,
+					toolChoice: options.toolMode ? { type: 'auto' } : undefined
+				},
+				undefined, // No streaming for now
+				token
+			);
+
+			this.logService.info(`Claude response completed. Tokens used: ${claudeResponse.usage?.input_tokens || 0} input, ${claudeResponse.usage?.output_tokens || 0} output`);
+
+			return {
+				stream: this._createResponseStream(claudeResponse.content?.[0]?.text || ''),
+				result: Promise.resolve({
+					text: claudeResponse.content?.[0]?.text || '',
+					usage: claudeResponse.usage
+				})
+			};
+
+		} catch (error) {
+			this.logService.error('Error in Claude chat response:', error);
+			throw error;
+		}
+	}
+
+	async provideTokenCount(
+		modelId: string,
+		message: string | IChatMessage,
+		token: CancellationToken
+	): Promise<number> {
+		// For now, use simple estimation
+		// In the future, we could use Claude's token counting API if available
+		const textToCount = typeof message === 'string' ? message : this._extractTextFromMessage(message);
+		return this.claudeApiClient.estimateTokens(textToCount);
+	}
+
+	private _convertMessagesToClaude(messages: IChatMessage[]): IClaudeMessage[] {
+		return messages.map(msg => {
+			const role = this._convertRole(msg.role);
+
+			// Handle array of content parts
+			if (Array.isArray(msg.content)) {
+				const content = msg.content.map(part => {
+					if ('type' in part) {
+						switch (part.type) {
+							case 'text':
+								return { type: 'text', text: part.value };
+							case 'image_url':
+								// Handle image content for vision models
+								if ('data' in part.value && 'mimeType' in part.value) {
+									return {
+										type: 'image',
+										source: {
+											type: 'base64',
+											media_type: part.value.mimeType,
+											data: part.value.data.toString('base64')
+										}
+									};
+								}
+								break;
+						}
+					}
+					return { type: 'text', text: String(part) };
+				});
+
+				return { role, content };
+			}
+
+			// Fallback to string conversion
+			return { role, content: msg.content.map(p => p.type === 'text' ? p.value : '').join('') };
+		});
+	}
+
+	private _convertRole(role: ChatMessageRole): 'system' | 'user' | 'assistant' {
+		switch (role) {
+			case ChatMessageRole.System: return 'system';
+			case ChatMessageRole.User: return 'user';
+			case ChatMessageRole.Assistant: return 'assistant';
+			default: return 'user';
+		}
+	}
+
+	private _extractTextFromMessage(message: IChatMessage): string {
+		if (Array.isArray(message.content)) {
+			return message.content
+				.map(part => {
+					if (part.type === 'text') return part.value;
+					return '';
+				})
+				.join(' ');
+		}
+
+		return '';
+	}
+
+	private _createResponseStream(text: string): IChatResponseStream {
+		// Simple implementation that yields the complete text
+		// In a real implementation, this would be a proper async iterator
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				yield { type: 'text', value: text };
+			}
+		} as IChatResponseStream;
+	}
+}

--- a/src/vs/workbench/contrib/claude/common/claudeTypes.ts
+++ b/src/vs/workbench/contrib/claude/common/claudeTypes.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface IClaudeConfiguration {
+	apiKey: string;
+	baseUrl?: string;
+	model: string;
+	maxTokens?: number;
+	temperature?: number;
+}
+
+export interface IClaudeMessage {
+	role: 'system' | 'user' | 'assistant';
+	content: string | Array<{
+		type: 'text' | 'image';
+		text?: string;
+		source?: {
+			type: 'base64';
+			media_type: string;
+			data: string;
+		};
+	}>;
+}
+
+export interface IClaudeResponse {
+	id: string;
+	type: 'message';
+	role: 'assistant';
+	content: Array<{
+		type: 'text';
+		text: string;
+	}>;
+	model: string;
+	stop_reason: string | null;
+	stop_sequence: string | null;
+	usage: {
+		input_tokens: number;
+		output_tokens: number;
+	};
+}
+
+export interface IClaudeStreamResponse {
+	type: 'message_start' | 'content_block_start' | 'content_block_delta' | 'content_block_stop' | 'message_delta' | 'message_stop';
+	message?: Partial<IClaudeResponse>;
+	content_block?: {
+		type: 'text';
+		text: string;
+	};
+	delta?: {
+		type: 'text_delta';
+		text: string;
+	};
+	usage?: {
+		input_tokens: number;
+		output_tokens: number;
+	};
+}
+
+export const CLAUDE_MODELS = {
+	'claude-3-5-sonnet-20241022': {
+		name: 'Claude 3.5 Sonnet',
+		family: 'claude-3-5',
+		maxInputTokens: 200000,
+		maxOutputTokens: 8192,
+		supportsVision: true,
+		supportsTools: true
+	},
+	'claude-3-5-haiku-20241022': {
+		name: 'Claude 3.5 Haiku',
+		family: 'claude-3-5',
+		maxInputTokens: 200000,
+		maxOutputTokens: 8192,
+		supportsVision: true,
+		supportsTools: true
+	},
+	'claude-3-opus-20240229': {
+		name: 'Claude 3 Opus',
+		family: 'claude-3',
+		maxInputTokens: 200000,
+		maxOutputTokens: 4096,
+		supportsVision: true,
+		supportsTools: true
+	}
+} as const;
+
+export type ClaudeModelId = keyof typeof CLAUDE_MODELS;

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -207,6 +207,7 @@ import './contrib/speech/browser/speech.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
 import './contrib/inlineChat/browser/inlineChat.contribution.js';
 import './contrib/mcp/browser/mcp.contribution.js';
+import './contrib/claude/browser/claude.contribution.js';
 
 // Interactive
 import './contrib/interactive/browser/interactive.contribution.js';


### PR DESCRIPTION
- Add Claude API client with Anthropic API integration
- Implement Claude language model provider compatible with VSCode chat system
- Add configuration service for API key management
- Create commands for API key setup and connection testing
- Support for Claude 3.5 Sonnet, Claude 3.5 Haiku, and Claude 3 Opus models
- Integration with existing VSCode chat infrastructure
- Proper error handling and logging

This is the foundational implementation for Claude integration.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
